### PR TITLE
Add setup script for dependency installation

### DIFF
--- a/requirements.text
+++ b/requirements.text
@@ -1,0 +1,43 @@
+MDFH Requirements
+=================
+
+The following system and software packages are needed to build and run the MDFH project.
+
+System Requirements
+-------------------
+* CPU: x86_64 or ARM64 (Apple Silicon supported)
+* Memory: 4GB RAM minimum (8GB+ recommended for high throughput)
+* Network: Gigabit Ethernet (10GbE+ recommended)
+
+Software Requirements
+---------------------
+* C++23 compatible compiler (GCC 12+, Clang 15+, or MSVC 2022+)
+* CMake 3.25 or later
+* Conan 2.0+
+
+Conan Packages
+--------------
+The build uses Conan to fetch the following libraries:
+* boost/1.85.0 (header only)
+* cli11/2.4.2
+* gtest/1.14.0
+* catch2/3.4.0
+* yaml-cpp/0.8.0
+
+Conan will automatically install these packages when running the provided scripts.
+
+Optional Dependencies
+---------------------
+These are only required for kernel bypass networking:
+* DPDK for Intel NICs (Linux only)
+* Solarflare OpenOnload for Solarflare NICs (Linux only)
+
+Building
+--------
+Use the scripts in the `scripts/` directory to set up dependencies and build the project:
+
+```
+./scripts/build.sh
+```
+
+This script installs the Conan packages, configures the build with CMake, and compiles the project.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Cross-platform setup script for MDFH
+# Installs required build tools and Conan package manager
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_section() {
+    echo -e "\n${BLUE}=== $1 ===${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}$1${NC}"
+}
+
+# Install packages on Debian/Ubuntu
+install_linux() {
+    print_section "Installing system packages (apt)"
+    sudo apt-get update
+    sudo apt-get install -y build-essential cmake python3 python3-pip git
+    print_success "Base packages installed"
+
+    print_section "Installing Conan via pip"
+    pip3 install --user --upgrade conan
+    print_success "Conan installed"
+}
+
+# Install packages on macOS using Homebrew
+install_macos() {
+    print_section "Installing system packages (brew)"
+    if ! command -v brew &>/dev/null; then
+        print_error "Homebrew not found. Please install Homebrew first: https://brew.sh/"
+        exit 1
+    fi
+    brew update
+    brew install cmake conan git
+    print_success "Homebrew packages installed"
+}
+
+# Detect platform and run appropriate installer
+case "$(uname)" in
+    Linux)
+        install_linux
+        ;;
+    Darwin)
+        install_macos
+        ;;
+    *)
+        print_error "Unsupported platform: $(uname)"
+        exit 1
+        ;;
+esac
+
+print_section "Setup complete"
+print_success "You can now run ./scripts/build.sh"
+


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to install build tools and Conan

## Testing
- `./run_tests.sh` *(fails: `conan: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684eef68608c832a905a568eab03e845